### PR TITLE
Add repository to package config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,6 @@
 name = "flake-iter"
 version = "0.1.0"
 edition = "2021"
-# This is a private repo and we'll error links to go to this public repo
-repository = "https://github.com/DeterminateSystems/ci"
 
 [dependencies]
 clap = { version = "4.5.7", default-features = false, features = [

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,7 +50,8 @@ impl Cli {
         let default_log_level = if verbose { Level::DEBUG } else { Level::INFO };
 
         color_eyre::config::HookBuilder::default()
-            .issue_url(concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new"))
+            // flake-iter is a private repo so we direct people to the ci repo for reporting issues
+            .issue_url("https://github.com/DeterminateSystems/ci/issues/new")
             .add_issue_metadata("version", env!("CARGO_PKG_VERSION"))
             .add_issue_metadata("os", std::env::consts::OS)
             .add_issue_metadata("arch", std::env::consts::ARCH)


### PR DESCRIPTION
Since the error hook is meant to provide a URL for submitting issues, we should ensure that `CARGO_PKG_REPOSITORY` is set.
