### PR TITLE
warn if there is no system (`system = []`)

### DIFF
--- a/src/cmd/systems.rs
+++ b/src/cmd/systems.rs
@@ -32,6 +32,10 @@ impl Systems {
 
         let (systems, systems_without_runners) = outputs.systems(runner_map);
 
+        if systems.is_empty() {
+            warn!("Flake does not include a nix system.");
+        }
+
         for system in systems_without_runners {
             warn!("Flake contains derivation outputs for Nix system `{system}` but no runner is specified for that system");
         }


### PR DESCRIPTION
when the result of `flake-iter systems` is `system = []`, this now emits this warning:

```
WARN flake_iter::cmd::systems: Flake does not include a nix system.
```

This is relevant (among other cases?) because https://github.com/DeterminateSystems/ci fails understandably ex-post, though somewhat cryptically on `system = []`.

I confused myself in https://github.com/DeterminateSystems/ci/issues/19, and I think reading something like the above error message in the GHA log might have gotten me on the right track earlier.

For a test, here is a (bad) flake which actually yields `system = []`: https://github.com/dataheld/nullkomma/pull/61/commits/e73b10cbe88291dbef47a3d38d422ef77c943539


---

How did I end up in this mess?
I didn't listen to your advice to *just use a homemade `forEachSystem`*, but went with `flake-utils`.
I then looped over `flake-schemas` with `flake-utils` 🙈, even though `flake-schemas` is universal ... and that caused `system = []` output.
I don't blame `flake-iter`, I think this is actually the correct output for that screwup of mine.