### PR TITLE
Use self in CI

### DIFF
--- a/.github/workflows/determinate-ci.yml
+++ b/.github/workflows/determinate-ci.yml
@@ -20,6 +20,7 @@ jobs:
       contents: "read"
     with:
       visibility: public
+      flake-iter-flakeref: ".#"
       runner-map: |
           {
             "aarch64-darwin": "macos-latest",


### PR DESCRIPTION
This PR uses this repo's contents (instead of the latest FlakeHub release) in the `DeterminateSystems/ci` workflow, in order to ensure no release inadvertently breaks downstream users of our reusable workflows.