### PR TITLE
Update to latest flake-schemas

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,16 +36,16 @@
     },
     "flake-schemas": {
       "locked": {
-        "lastModified": 1721999734,
-        "narHash": "sha256-G5CxYeJVm4lcEtaO87LKzOsVnWeTcHGKbKxNamNWgOw=",
-        "rev": "0a5c42297d870156d9c57d8f99e476b738dcd982",
-        "revCount": 75,
+        "lastModified": 1772200446,
+        "narHash": "sha256-hcUPpu25+VLvQsf961cu4zTeA//Ab35MaMjqSS/Ojqc=",
+        "rev": "d6a6b7cfa25bea552c197c9e227cd293ff801dbb",
+        "revCount": 115,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/flake-schemas/0.1.5/0190ef2f-61e0-794b-ba14-e82f225e55e6/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/flake-schemas/0.3.0/019c9f61-e746-760e-a1fe-53f05b10d026/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/flake-schemas/0.1"
+        "url": "https://flakehub.com/f/DeterminateSystems/flake-schemas/0.3"
       }
     },
     "nixpkgs": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     crane = {
       url = "https://flakehub.com/f/ipetkov/crane/0.20";
     };
-    flake-schemas.url = "https://flakehub.com/f/DeterminateSystems/flake-schemas/0.1";
+    flake-schemas.url = "https://flakehub.com/f/DeterminateSystems/flake-schemas/0.3";
   };
 
   outputs =


### PR DESCRIPTION
Fixes
```
error: Flake 'git+file:///home/eelco/Determinate/flake-iter' does not have any schema that provides a default output for the role(s) nix-develop.
```

Flake lock file updates:

• Updated input 'flake-schemas':
    'https://api.flakehub.com/f/pinned/DeterminateSystems/flake-schemas/0.1.5/0190ef2f-61e0-794b-ba14-e82f225e55e6/source.tar.gz' (2024-07-26)
  → 'https://api.flakehub.com/f/pinned/DeterminateSystems/flake-schemas/0.3.0/019c9f61-e746-760e-a1fe-53f05b10d026/source.tar.gz' (2026-02-27)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->